### PR TITLE
Update link and add non-maintained status

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Table of Contents
 ## Frameworks/Servers for Serving
 
 - [BentoML](https://github.com/bentoml/BentoML) ![](https://img.shields.io/github/stars/bentoml/BentoML.svg?style=social) - The Unified Model Serving Framework
-- [Cortex](https://www.cortex.dev/) ![](https://img.shields.io/github/stars/cortexlabs/cortex?style=social) - Open source platform for deploying machine learning models in production.
+- [Cortex](https://github.com/cortexlabs/cortex) ![](https://img.shields.io/github/stars/cortexlabs/cortex?style=social) - Open source platform for deploying machine learning models in production. (No longer maintained).
 - [ForestFlow](https://github.com/ForestFlow/ForestFlow) ![](https://img.shields.io/github/stars/ForestFlow/ForestFlow.svg?style=social) - Policy-driven Machine Learning Model Server.
 - [Multi Model Server](https://github.com/awslabs/multi-model-server) ![](https://img.shields.io/github/stars/awslabs/multi-model-server.svg?style=social) - Multi Model Server is a tool for serving neural net models for inference.
 - [Neuropod](https://github.com/uber/neuropod) ![](https://img.shields.io/github/stars/uber/neuropod.svg?style=social) - A uniform interface to run deep learning models from multiple frameworks

--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ Table of Contents
 ## Frameworks/Servers for Serving
 
 - [BentoML](https://github.com/bentoml/BentoML) ![](https://img.shields.io/github/stars/bentoml/BentoML.svg?style=social) - The Unified Model Serving Framework
-- [Cortex](https://github.com/cortexlabs/cortex) ![](https://img.shields.io/github/stars/cortexlabs/cortex?style=social) - Open source platform for deploying machine learning models in production. (No longer maintained).
 - [ForestFlow](https://github.com/ForestFlow/ForestFlow) ![](https://img.shields.io/github/stars/ForestFlow/ForestFlow.svg?style=social) - Policy-driven Machine Learning Model Server.
 - [Multi Model Server](https://github.com/awslabs/multi-model-server) ![](https://img.shields.io/github/stars/awslabs/multi-model-server.svg?style=social) - Multi Model Server is a tool for serving neural net models for inference.
 - [Neuropod](https://github.com/uber/neuropod) ![](https://img.shields.io/github/stars/uber/neuropod.svg?style=social) - A uniform interface to run deep learning models from multiple frameworks


### PR DESCRIPTION
Cortex.dev no longer works as a URL.

Given that it's unmaintained, maybe you want to remove it from the list completely? For now, I just added a note to that effect.