### PR TITLE
add Kurtosis under "IDEs & Workspaces"

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Table of Contents
 - [Docker](https://github.com/moby/moby) ![](https://img.shields.io/github/stars/moby/moby.svg?style=social) - Moby is an open-source project created by Docker to enable and accelerate software containerization.
 - [envd](https://github.com/tensorchord/envd) ![](https://img.shields.io/github/stars/tensorchord/envd.svg?style=social) - 🏕️ Reproducible development environment for AI/ML.
 - [Jupyter Notebooks](https://github.com/jupyter/notebook) ![](https://img.shields.io/github/stars/jupyter/notebook.svg?style=social) - The Jupyter notebook is a web-based notebook environment for interactive computing.
+- [Kurtosis](https://github.com/kurtosis-tech/kurtosis) ![](https://img.shields.io/github/stars/kurtosistech/kurtosis.svg?style=social) - A build, packaging, and run system for ephemeral multi-container environments.
 
 **[⬆ back to ToC](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Table of Contents
 - [Docker](https://github.com/moby/moby) ![](https://img.shields.io/github/stars/moby/moby.svg?style=social) - Moby is an open-source project created by Docker to enable and accelerate software containerization.
 - [envd](https://github.com/tensorchord/envd) ![](https://img.shields.io/github/stars/tensorchord/envd.svg?style=social) - 🏕️ Reproducible development environment for AI/ML.
 - [Jupyter Notebooks](https://github.com/jupyter/notebook) ![](https://img.shields.io/github/stars/jupyter/notebook.svg?style=social) - The Jupyter notebook is a web-based notebook environment for interactive computing.
-- [Kurtosis](https://github.com/kurtosis-tech/kurtosis) ![](https://img.shields.io/github/stars/kurtosistech/kurtosis.svg?style=social) - A build, packaging, and run system for ephemeral multi-container environments.
+- [Kurtosis](https://github.com/kurtosis-tech/kurtosis) ![](https://img.shields.io/github/stars/kurtosis-tech/kurtosis.svg?style=social) - A build, packaging, and run system for ephemeral multi-container environments.
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
I am a dev at Kurtosis. We allow people to spin up containers in ephemeral environments that are isolated from each other using Starlark.

We have seen some traction with our https://github.com/kurtosis-tech/autogpt-package where people use us to spin up AutoGPT against Redis, Weaviate, pinecone etc based on the arguments people pass.

This allows folks to convert long READMEs + setup scripts + multiple docker composes into one script. We think of ourselves as an easier & more powerful Docker compose.

While we have seen people use it to "run" their multi container environments as a single binary; we also offer SDKs that make testing easier; if your application is containerized.

Let me know if this can be added :-) 