### PR TITLE
Add `finetuning-scheduler` to Foundation Model Fine Tuning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Contributions are most welcome, please adhere to the [contribution guidelines](c
 ## Foundation Model Fine Tuning
 
 - [alpaca-lora](https://github.com/tloen/alpaca-lora) ![](https://img.shields.io/github/stars/tloen/alpaca-lora.svg?style=social) - Instruct-tune LLaMA on consumer hardware
+- [finetuning-scheduler](https://github.com/speediedan/finetuning-scheduler) ![](https://img.shields.io/github/stars/speediedan/finetuning-scheduler.svg?style=social) - A PyTorch Lightning extension that accelerates and enhances foundation model experimentation with flexible fine-tuning schedules.
 - [LMFlow](https://github.com/OptimalScale/LMFlow) ![](https://img.shields.io/github/stars/OptimalScale/LMFlow.svg?style=social) - An Extensible Toolkit for Finetuning and Inference of Large Foundation Models
 - [Lora](https://github.com/cloneofsimo/lora) ![](https://img.shields.io/github/stars/cloneofsimo/lora.svg?style=social) - Using Low-rank adaptation to quickly fine-tune diffusion models.
 - [peft](https://github.com/huggingface/peft) ![](https://img.shields.io/github/stars/huggingface/peft.svg?style=social) - State-of-the-art Parameter-Efficient Fine-Tuning.


### PR DESCRIPTION
Thanks again for maintaining this useful summary of the LLMOps package landscape! 

This PR humbly suggests the addition of the [`finetuning-scheduler`](https://github.com/speediedan/finetuning-scheduler) package.
![image](https://github.com/tensorchord/Awesome-LLMOps/assets/7462936/0ef10325-8d1c-4bfe-8a91-3bf3dc896d89)

`finetuning-scheduler` is a PyTorch Lightning extension that accelerates and enhances foundation model experimentation with flexible fine-tuning schedules. 

The popular PyTorch Lightning package uses this extension for its `Fine Tuning` [tutorial](https://lightning.ai/docs/pytorch/stable/tutorials.html). It's primary utility is facilitating foundation model research and exploration with advanced fine-tuning configurations. Full disclosure, I'm the primary maintainer of `finetuning-scheduler` and a frequent contributor to both PyTorch and PyTorch Lightning.

I appreciated you considering this PR. Thanks again for this useful catalog!
