### PR TITLE
Add promptfoo to LLM security frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | Project                                                 | Details                                                                                                                             | Repository                                                                                    |
 | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
+| [promptfoo](https://github.com/promptfoo/promptfoo) | LLM red teaming and evaluation framework. Test for jailbreaks, prompt injection, and other vulnerabilities with adversarial attacks. CI/CD integration. | ![GitHub Badge](https://img.shields.io/github/stars/promptfoo/promptfoo?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Adds [promptfoo](https://github.com/promptfoo/promptfoo) to the Security > Frameworks for LLM security section.

**promptfoo** is an open-source LLM red teaming and evaluation framework:

- **Red teaming**: Test for jailbreaks, prompt injection, and other vulnerabilities
- **Adversarial attacks**: PAIR, tree-of-attacks, crescendo multi-turn strategies
- **CI/CD integration**: Automate security testing in pipelines
- **Evaluation**: Compare prompts, models, and RAG systems

250K+ developers, featured in OpenAI Build Hours and Anthropic's courses.