### PR TITLE
Add semantic-coverage to Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [Maxim AI](https://getmaxim.ai) | Platform for AI Agent Simulation, Evaluation & Observability |
 | [traceAI](https://github.com/future-agi/traceAI)                                | Open-source AI tracing framework built on OpenTelemetry for deep observability across agentic and LLM workflows.                                                                   | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/traceAI?style=flat-square)                         |
 | [Future AGI](https://github.com/future-agi/futureagi-sdk)                    | Production-grade SDK for observability, automated evaluations and prompt management with sub-100ms guardrails for LLM/agent workflows.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
-- [semantic-coverage](https://github.com/aashirpersonal/semantic-coverage) - Visualizes RAG knowledge gaps and "blind spots" using 2D UMAP clustering and density detection.
+| [semantic-coverage](https://github.com/aashirpersonal/semantic-coverage) | Visualizes RAG knowledge gaps and "blind spots" using 2D UMAP clustering and density detection.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Hi! I'd like to submit semantic-coverage, an open-source tool for RAG observability.

Why it fits: Unlike existing evaluation tools that focus on generic metrics, this tool visualizes "Semantic Coverage" (the spatial gap between user queries and vector documents) using UMAP + HDBSCAN. It helps engineers identify "Blind Spots" where users are asking questions that have zero matching documentation.

Repo: https://github.com/aashirpersonal/semantic-coverage

Thanks for maintaining this list!