### PR TITLE
Add EvalView CLI tool to Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [traceAI](https://github.com/future-agi/traceAI)                                | Open-source AI tracing framework built on OpenTelemetry for deep observability across agentic and LLM workflows.                                                                   | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/traceAI?style=flat-square)                         |
 | [Future AGI](https://github.com/future-agi/futureagi-sdk)                    | Production-grade SDK for observability, automated evaluations and prompt management with sub-100ms guardrails for LLM/agent workflows.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
 | [semantic-coverage](https://github.com/aashirpersonal/semantic-coverage) | Visualizes RAG knowledge gaps and "blind spots" using 2D UMAP clustering and density detection.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
+ | [EvalView](https://github.com/hidai25/eval-view) | CLI tool for testing and evaluating multi-step AI agents. YAML-based test cases with regression detection, baseline snapshots, and production monitoring. | ![GitHub Badge](https://img.shields.io/github/stars/hidai25/eval-view.svg?style=flat-square) |
+
+
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
 EvalView is a CLI tool for regression testing AI agents. It snapshots the full execution
  trace (tool calls, parameters, sequence, output) and diffs it after changes.

  - Golden baseline regression detection
  - 14 agent framework adapters
  - Production monitoring with Slack alerts
  - Free deterministic checks without API keys
  - 1,600+ PyPI installs, Apache 2.0 licensed

  GitHub: https://github.com/hidai25/eval-view