### PR TITLE
Add kimi-k-cli to Code AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [fauxpilot](https://github.com/fauxpilot/fauxpilot) | An open-source alternative to GitHub Copilot server                                                      | ![GitHub Badge](https://img.shields.io/github/stars/fauxpilot/fauxpilot.svg?style=flat-square)  |
 | [promptext](https://github.com/1broseidon/promptext) | Smart code context extractor for AI assistants with accurate token counting and budget management        | ![GitHub Badge](https://img.shields.io/github/stars/1broseidon/promptext.svg?style=flat-square) |
 | [tabby](https://github.com/TabbyML/tabby)           | Self-hosted AI coding assistant. An opensource / on-prem alternative to GitHub Copilot.                  | ![GitHub Badge](https://img.shields.io/github/stars/TabbyML/tabby.svg?style=flat-square)        |
+| [kimi-k-cli](https://github.com/suebi76/kimi-k-cli) | Self-improving terminal AI coding assistant with 11 tools, plugin system, and self-improvement. Powered by Kimi K2.5 via free NVIDIA NIM API. | ![GitHub Badge](https://img.shields.io/github/stars/suebi76/kimi-k-cli.svg?style=flat-square) |
 
 ## Training
 


### PR DESCRIPTION
## Addition

Adding [kimi-k-cli](https://github.com/suebi76/kimi-k-cli) to the **Code AI** section.

A self-improving terminal AI coding assistant powered by Kimi K2.5 (Moonshot AI) via the free NVIDIA NIM API.

### Features
- 11 built-in tools (bash, file read/write/edit, grep, glob, web search, web fetch, memory, self-improve)
- Plugin system for custom tool extensions
- Self-improvement: can read/edit its own source code
- Thinking mode with reasoning traces
- Single Python file, MIT licensed