### PR TITLE
Add TraceHawk to Observability section — MCP-native AI agent monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [traceAI](https://github.com/future-agi/traceAI)                                | Open-source AI tracing framework built on OpenTelemetry for deep observability across agentic and LLM workflows.                                                                   | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/traceAI?style=flat-square)                         |
 | [Future AGI](https://github.com/future-agi/futureagi-sdk)                    | Production-grade SDK for observability, automated evaluations and prompt management with sub-100ms guardrails for LLM/agent workflows.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
 | [semantic-coverage](https://github.com/aashirpersonal/semantic-coverage) | Visualizes RAG knowledge gaps and "blind spots" using 2D UMAP clustering and density detection.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
+| [TraceHawk](https://tracehawk.com) | MCP-native observability for AI agents. First-class MCP tracing with per-server analytics, cost attribution, and production alerts. Built on OpenTelemetry. Free tier: 50K spans/month. | |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
TraceHawk is an observability platform built for MCP-era AI agents.

- First-class MCP tracing: per-server analytics, latency, cost attribution
- Works with LangGraph, CrewAI, OpenAI Agents SDK, Claude Code
- Built on OpenTelemetry (OpenLLMetry)
- Free tier: 50K spans/month

https://tracehawk.com