### PR TITLE
Add ClawSearch - AI agent skill security search

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 
 | Project                                                 | Details                                                                                                                             | Repository                                                                                    |
 | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| [ClawSearch](https://clawsearch.cc) | Security-first search engine for AI agent skills with Trust Score, 10-language semantic search, and npm supply chain safety tools. | |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**


### PR DESCRIPTION
## Summary

- Adds [ClawSearch](https://clawsearch.cc) to the **Security > Frameworks for LLM security** section
- ClawSearch is a security-first search engine for AI agent skills with Trust Score, 10-language semantic search, and npm supply chain safety tools

Entry added in the table format following the existing conventions.