### PR TITLE
Add XVARY Stock Research (Claude Code skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,3 +643,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [pleisto/flappy](https://github.com/pleisto/flappy)                                                     | Production-Ready LLM Agent SDK for Every Developer                                                                                | ![GitHub Badge](https://img.shields.io/github/stars/pleisto/flappy.svg?style=flat-square)                                |
 
 **[⬆ back to ToC](#table-of-contents)**
+## XVARY Stock Research
+
+- [XVARY Stock Research](https://github.com/xvary-research/claude-code-stock-analysis-skill) — Claude Code skill for public SEC EDGAR + market data: `/analyze`, `/score`, `/compare`. MIT.
+


### PR DESCRIPTION
Adds [xvary-research/claude-code-stock-analysis-skill](https://github.com/xvary-research/claude-code-stock-analysis-skill) — MIT, public SEC EDGAR + market data workflow (`/analyze`, `/score`, `/compare`) for Claude Code / compatible agents.

Inserted as a short README section before Contributing/License where possible.