### PR TITLE
Add VeroQ - LLM output verification and monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [traceAI](https://github.com/future-agi/traceAI)                                | Open-source AI tracing framework built on OpenTelemetry for deep observability across agentic and LLM workflows.                                                                   | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/traceAI?style=flat-square)                         |
 | [Future AGI](https://github.com/future-agi/futureagi-sdk)                    | Production-grade SDK for observability, automated evaluations and prompt management with sub-100ms guardrails for LLM/agent workflows.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
 | [semantic-coverage](https://github.com/aashirpersonal/semantic-coverage) | Visualizes RAG knowledge gaps and "blind spots" using 2D UMAP clustering and density detection.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
+| [VeroQ Shield](https://github.com/veroq-ai/shield) | Verify any LLM output in one function call. Extracts claims, fact-checks against live evidence, and returns trust scores, corrections, and permanent verification receipts. | ![GitHub Badge](https://img.shields.io/github/stars/veroq-ai/shield?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
## What is VeroQ?

[VeroQ Shield](https://github.com/veroq-ai/shield) verifies any LLM output in one function call:

```python
from veroq import shield
result = shield("NVIDIA reported $22B in Q4 revenue")
print(result.trust_score)   # 0.73
print(result.corrections)   # [{claim, correction}]
```

- Extracts claims from any LLM text
- Verifies each against live evidence (web search, financial data, public records)
- Returns trust score, corrections, and permanent verification receipts
- Python (`pip install veroq`) and TypeScript (`npm install @veroq/sdk`)
- 2,000+ weekly installs across npm and PyPI