### PR TITLE
Add Not Human Search to Search section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ An awesome & curated list of the best LLMOps tools for developers.
     - [Observability](#observability)
   - [LLMOps](#llmops)
   - [Search](#search)
+    - [AI Tool Discovery](#ai-tool-discovery)
     - [Vector search](#vector-search)
   - [Code AI](#code-ai)
   - [Training](#training)
@@ -261,6 +262,14 @@ An awesome & curated list of the best LLMOps tools for developers.
 **[⬆ back to ToC](#table-of-contents)**
 
 ## Search
+
+### AI Tool Discovery
+
+| Project                                                   | Details                                                                                                                                                                                       | Repository                                                                                            |
+| --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| [Not Human Search](https://nothumansearch.ai)             | Search engine for AI agents indexing 9,000+ AI tools and APIs by agentic readiness (llms.txt, OpenAPI, MCP, ai-plugin.json). REST API and MCP server for programmatic discovery.               |                                                                                                       |
+
+**[⬆ back to ToC](#table-of-contents)**
 
 ### Vector search
 


### PR DESCRIPTION
Add [Not Human Search](https://nothumansearch.ai) under a new "AI Tool Discovery" subsection in the Search section.

Not Human Search is a search engine built for AI agents that indexes 9,000+ AI tools and APIs, scoring them by agentic readiness signals like llms.txt, OpenAPI specs, MCP servers, and ai-plugin.json manifests. It provides a REST API and MCP server for programmatic discovery.

This adds a new subcategory under Search, as the tool doesn't fit under Vector search but is relevant to AI/LLM infrastructure discovery.