### PR TITLE
Add OpenPaths to Frameworks/Servers for Serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [KubeAI](https://github.com/substratusai/kubeai)                       | Deploy and scale machine learning models on Kubernetes. Built for LLMs, embeddings, and speech-to-text. | ![GitHub Badge](https://img.shields.io/github/stars/substratusai/kubeai.svg?style=flat-square)             |
 | [Kaito](https://github.com/kaito-project/kaito)                            | A Kubernetes operator that simplifies serving and tuning large AI models (e.g. Falcon or phi-3) using container images and GPU auto-provisioning. Includes an OpenAI-compatible server for inference and preset configurations for popular runtimes such as vLLM and transformers.                                                                 | ![GitHub Badge](https://img.shields.io/github/stars/kaito-project/kaito.svg?style=flat-square)            |
 | [Open Responses](https://docs.julep.ai/open-responses) | Serverless open-source platform for building long-running LLM agents with tool use. | ![GitHub Badge](https://img.shields.io/github/stars/julep-ai/julep.svg?style=flat-square) |
+| [OpenPaths](https://openpaths.io)                       | Open source model router with universal API. Routes requests to the lowest-latency, highest-throughput LLM provider. |                                                                                                    |
 
 
 **[⬆ back to ToC](#table-of-contents)**


### PR DESCRIPTION
## Summary
- Adds [OpenPaths](https://openpaths.io) to the Frameworks/Servers for Serving section
- OpenPaths is an open source model router with a universal API that routes requests to the lowest-latency, highest-throughput LLM provider.

## Test plan
- [ ] Verify link resolves correctly
- [ ] Verify entry follows existing table format