### PR TITLE
Add BenchGecko to LLMOps tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,3 +649,4 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [pleisto/flappy](https://github.com/pleisto/flappy)                                                     | Production-Ready LLM Agent SDK for Every Developer                                                                                | ![GitHub Badge](https://img.shields.io/github/stars/pleisto/flappy.svg?style=flat-square)                                |
 
 **[⬆ back to ToC](#table-of-contents)**
+- [BenchGecko](https://benchgecko.ai) - AI model benchmark tracking and cross-provider pricing comparison for model selection. Free API.


### PR DESCRIPTION
Adds BenchGecko as an LLMOps tool for model selection and cost optimization.

Compare benchmark scores and pricing across providers before deploying.

https://benchgecko.ai