### PR TITLE
Add REG-Vault (retro-gaming metadata + MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,3 +649,5 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [pleisto/flappy](https://github.com/pleisto/flappy)                                                     | Production-Ready LLM Agent SDK for Every Developer                                                                                | ![GitHub Badge](https://img.shields.io/github/stars/pleisto/flappy.svg?style=flat-square)                                |
 
 **[⬆ back to ToC](#table-of-contents)**
+
+- [REG-Vault](https://regvault.org/docs/api) - MCP server exposing 91k retro-gaming records. Spec 2025-03-26, JSON-RPC 2.0.


### PR DESCRIPTION
Adds **REG-Vault** — an open retro-gaming metadata catalog (91,000+ games, 99 systems) with REST API + MCP server at `api.regvault.org/mcp`.

- Home: https://regvault.org
- API docs: https://regvault.org/docs/api
- MCP endpoint: https://api.regvault.org/mcp (JSON-RPC 2.0, spec 2025-03-26)

Tools exposed: `list_systems`, `search_games`, `get_game`, `get_letter_counts`, `get_stats`.
