### PR TITLE
Add peyeeye to Security / Frameworks for LLM security

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 
 | Project                                                 | Details                                                                                                                             | Repository                                                                                    |
 | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| [peyeeye](https://peyeeye.ai) | PII redaction and rehydration for LLM prompts. Hybrid regex + checksum validators (Luhn, mod-97, SSN) with optional Piiranha/Presidio ML layer. Stateful sessions or stateless AEAD-sealed blobs. Python + TypeScript SDKs with Vercel AI SDK, LangChain, and LiteLLM integrations. | ![GitHub Badge](https://img.shields.io/github/stars/peyeeye/peyeeye-python.svg?style=flat-square) |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**


### PR DESCRIPTION
Adds [peyeeye](https://peyeeye.ai) to **Security → Frameworks for LLM security**.

## What it is

peyeeye is a PII redaction and rehydration API for LLM prompts. It sits between your application and the model:

- **Redact**: strips PII from prompts before they hit the LLM (emails, cards, SSNs, IPs, phone numbers, custom entities)
- **Rehydrate**: restores the original values in the LLM's response on the way back
- **Hybrid detection**: regex + checksum validators (Luhn for cards, mod-97 for IBANs, SSN structure, IP validity) with an optional Piiranha (DeBERTa-v3) / Presidio ML layer
- **Stateful sessions or stateless AEAD-sealed blobs** — stateless mode returns a self-contained `skey_…` rehydration key, no server-side session retention required
- **SDKs**: [Python](https://github.com/peyeeye/peyeeye-python) and [TypeScript](https://github.com/peyeeye/peyeeye-typescript), with native integrations for Vercel AI SDK, LangChain, LangChain.js, and LiteLLM

## Why it fits

The section currently lists adversarial-attack testing (Plexiglass). peyeeye covers the adjacent production concern: preventing PII from leaving your infrastructure in the first place. Relevant to anyone running LLMs against prompts that may contain customer data.

## Disclosure

I'm the maintainer.

## Checklist

- [x] Entry placed alphabetically within the category
- [x] Individual PR for a single suggestion
- [x] Description is factual, not promotional