### PR TITLE
Add AgentGuard to Frameworks for LLM security

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 
 | Project                                                 | Details                                                                                                                             | Repository                                                                                    |
 | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| [AgentGuard](https://github.com/MukundaKatta/AgentGuard) | Network-egress firewall for AI agent tools. Declarative allowlist of domains agent tools can fetch, throws on violation. Stops data exfiltration via tool-call URLs. | ![GitHub Badge](https://img.shields.io/github/stars/MukundaKatta/AgentGuard?style=flat-square) |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**


### PR DESCRIPTION
Adds AgentGuard to the "Frameworks for LLM security" section.

[AgentGuard](https://github.com/MukundaKatta/AgentGuard) is a network-egress firewall for AI agent tools. You declare an allowlist of domains the agent's `fetch` (or HTTP client) is permitted to reach, and any out-of-policy request throws synchronously. It's a small primitive aimed at one specific failure mode: tool-call-driven data exfiltration where a prompt-injected agent quietly POSTs to an attacker URL.

Distinct from Plexiglass (red-team toolbox) — AgentGuard is a runtime guardrail, not a pentesting toolkit.

- Repo: https://github.com/MukundaKatta/AgentGuard
- npm: `@mukundakatta/agentguard`
- Inserted alphabetically (A before P) in the existing security table; same column format.