### PR TITLE
Add Credyt for cost observability in AI products

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [traceAI](https://github.com/future-agi/traceAI)                                | Open-source AI tracing framework built on OpenTelemetry for deep observability across agentic and LLM workflows.                                                                   | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/traceAI?style=flat-square)                         |
 | [Future AGI](https://github.com/future-agi/futureagi-sdk)                    | Production-grade SDK for observability, automated evaluations and prompt management with sub-100ms guardrails for LLM/agent workflows.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
 | [semantic-coverage](https://github.com/aashirpersonal/semantic-coverage) | Visualizes RAG knowledge gaps and "blind spots" using 2D UMAP clustering and density detection.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
+| [Credyt](https://credyt.ai) | Real-time cost observability and monetization for AI-native products.                                             |                    |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Adds Credyt (https://credyt.ai), monetization infrastructure for AI products that enables real-time observability of workload costs and profitability.