### PR TITLE
Add distill-json to Optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [TNN](https://github.com/Tencent/TNN)                                             | A uniform deep learning inference framework for mobile, desktop and server.                                                      | ![GitHub Badge](https://img.shields.io/github/stars/Tencent/TNN.svg?style=flat-square)                   |
 | [optimum-tpu](https://github.com/huggingface/optimum-tpu)                         | Google TPU optimizations for transformers models                                                                                 | ![GitHub Badge](https://img.shields.io/github/stars/huggingface/optimum-tpu.svg?style=flat-square)       |
 | [agent-opt](https://github.com/future-agi/agent-opt) | Automated optimization engine for improving agent workflows using feedback-driven iterative refinements. | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/agent-opt?style=flat-square) |
+| [distill-json](https://github.com/karthyick/DISTILL) | Lossless JSON compression for LLM payloads — reduces tokens 60-85% via schema extraction, dictionary encoding, and equivalence partitioning. Drop-in replacement for `json.dumps()`. | ![GitHub Badge](https://img.shields.io/github/stars/karthyick/DISTILL.svg?style=flat-square) |
 
 
 **[⬆ back to ToC](#table-of-contents)**


### PR DESCRIPTION
Adding [**distill-json**](https://github.com/karthyick/DISTILL) under **Optimizations**.

It's a Python library for **lossless JSON compression** specifically designed for LLM payloads. It reduces token counts 60-85% on repeated/structured records while keeping the output human-and-LLM-readable (no binary blobs).

Why it fits Optimizations: it's an inference-cost optimization tool — every JSON payload sent to an LLM API costs money, and this directly reduces that cost without changing your prompts or model.

**Key facts:**
- ~5K downloads on PyPI: `pip install distill-json`
- 100% lossless roundtrip, exact type preservation
- Three-layer approach: schema extraction → dictionary encoding → equivalence partitioning
- Drop-in for `json.dumps()` in OpenAI / Anthropic / LangChain workflows
- MIT license

Thanks for maintaining this list!