### PR TITLE
Add skill-audit-mcp to Frameworks for LLM security

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | Project                                                 | Details                                                                                                                             | Repository                                                                                    |
 | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
+| [skill-audit-mcp](https://github.com/eltociear/skill-audit-mcp) | Static security scanner for MCP servers, AI agent skills, and plugins. Detects 68 attack patterns across CRITICAL/HIGH/MEDIUM/LOW — credential exfiltration, prompt injection, code execution, seed-phrase harvesting, auth bypass, path traversal. SARIF output for GitHub Code Scanning, multi-arch Docker image, and GitHub Action (`uses: eltociear/skill-audit-mcp@v1`). Zero dependencies, Python 3.6+. | ![GitHub Badge](https://img.shields.io/github/stars/eltociear/skill-audit-mcp?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Adds [skill-audit-mcp](https://github.com/eltociear/skill-audit-mcp) to **Frameworks for LLM security**.

Static security scanner specifically for MCP servers, AI agent skill files, and LLM tool definitions. Where Plexiglass tests model outputs adversarially, skill-audit-mcp scans the **agent tooling layer** — the place where most production prompt-injection and credential-exfiltration attacks actually land.

**Detects 68 attack patterns across 4 severity levels:**

- **CRITICAL** — credential exfiltration, seed-phrase harvest, download-and-execute
- **HIGH** — arbitrary code execution, auth bypass, identity impersonation
- **MEDIUM** — prompt injection (instruction override, role hijack, hidden Unicode, encoded payloads), obfuscation, privilege escalation
- **LOW** — external URL refs, broad filesystem access

**Distribution:**
- GitHub Action: `uses: eltociear/skill-audit-mcp@v1` → SARIF → GitHub Code Scanning
- Docker (multi-arch): `ghcr.io/eltociear/skill-audit-mcp:v1`
- MCP server: `python3 scanner.py --mcp` (three tools: audit / audit_file / audit_directory)
- Hosted x402 API: pay-per-scan via USDC micropayments on Base

Zero dependencies, Python 3.6+, MIT, Glama-verified.