### PR TITLE
Add AgentLens to Observability section

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [traceAI](https://github.com/future-agi/traceAI)                                | Open-source AI tracing framework built on OpenTelemetry for deep observability across agentic and LLM workflows.                                                                   | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/traceAI?style=flat-square)                         |
 | [Future AGI](https://github.com/future-agi/futureagi-sdk)                    | Production-grade SDK for observability, automated evaluations and prompt management with sub-100ms guardrails for LLM/agent workflows.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
 | [semantic-coverage](https://github.com/aashirpersonal/semantic-coverage) | Visualizes RAG knowledge gaps and "blind spots" using 2D UMAP clustering and density detection.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
+| [AgentLens](https://github.com/Soufianeazz/agentlens) | Self-hosted LLM observability with built-in air-gap mode. Quality scoring, agent waterfalls, prompt debugger, GDPR-native compliance workflows. BSL 1.1 server + MIT SDK. | ![GitHub Badge](https://img.shields.io/github/stars/Soufianeazz/agentlens?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Adds AgentLens to the Observability section.

AgentLens is a self-hosted LLM observability platform with built-in air-gap mode, quality scoring, agent waterfall debugging, prompt-level inspection, and GDPR-native compliance workflows. Open-core: BSL 1.1 for the server, MIT for the Python SDK.

- Repo: https://github.com/Soufianeazz/agentlens
- Live demo: https://www.agentlens.one
- PyPI: https://pypi.org/project/agentlens-monitor/

Entry placed at the end of the section per current addition-order convention. Stars badge follows the existing format.