### PR TITLE
Add APort to Frameworks for LLM security

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 
 | Project                                                 | Details                                                                                                                             | Repository                                                                                    |
 | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| [APort](https://aport.io)                               | Agent identity and policy-enforcement platform for LLM and AI-agent tool calls, with [guardrail integration examples](https://github.com/aporthq/aport-integrations). | ![GitHub Badge](https://img.shields.io/github/stars/aporthq/aport-integrations.svg?style=flat-square) |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**


### PR DESCRIPTION
Adds APort to the Frameworks for LLM security section.

- Links the APort website
- Includes the APort guardrail integration examples repository
- Keeps the entry alphabetized within the category