### PR TITLE
Add Stoic AgentOS under Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [traceAI](https://github.com/future-agi/traceAI)                                | Open-source AI tracing framework built on OpenTelemetry for deep observability across agentic and LLM workflows.                                                                   | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/traceAI?style=flat-square)                         |
 | [Future AGI](https://github.com/future-agi/futureagi-sdk)                    | Production-grade SDK for observability, automated evaluations and prompt management with sub-100ms guardrails for LLM/agent workflows.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
 | [semantic-coverage](https://github.com/aashirpersonal/semantic-coverage) | Visualizes RAG knowledge gaps and "blind spots" using 2D UMAP clustering and density detection.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
+| [Stoic AgentOS](https://github.com/benjaminkernbaum-ux/stoic-agentos) | Observability and persistent memory for AI agent fleets — heartbeats, run stats, decision/error timeline, and cross-session knowledge items. SDK on npm, free tier, multi-tenant. | ![GitHub Badge](https://img.shields.io/github/stars/benjaminkernbaum-ux/stoic-agentos.svg?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Adding [Stoic AgentOS](https://github.com/benjaminkernbaum-ux/stoic-agentos) — open-source observability + memory for AI agent fleets. SDK on npm, free tier, multi-tenant. Fits the Observability section alongside Langfuse / Helicone / Phoenix.\n\nLive: https://stoicagentos.com\nRepo: https://github.com/benjaminkernbaum-ux/stoic-agentos\nSDK: https://www.npmjs.com/package/stoic-agentos-sdk