### PR TITLE
Add AI Models Catalog — structured YAML catalog of 4,587+ AI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [Mixtral-8x7B-v0.1](https://huggingface.co/mistralai/Mixtral-8x7B-v0.1) | The Mixtral-8x7B Large Language Model (LLM) is a pretrained generative Sparse Mixture of Experts.                                                                                          |                                                                                                           |
 | [StableLM](https://github.com/Stability-AI/StableLM)                    | StableLM: Stability AI Language Models                                                                                                                                                     | ![GitHub Badge](https://img.shields.io/github/stars/Stability-AI/StableLM.svg?style=flat-square)          |
 
+| [AI Models Catalog](https://github.com/i-need-token/ai-models) | Structured catalog of 4,587+ AI models across 95 providers with pricing, context windows, and capabilities. Interactive catalog at https://i-need-token.github.io/ai-models/ | ![GitHub Badge](https://img.shields.io/github/stars/i-need-token/ai-models.svg?style=flat-square) |
+
 **[⬆ back to ToC](#table-of-contents)**
 
 ### CV Foundation Model


### PR DESCRIPTION
## Addition

**AI Models Catalog** — https://github.com/i-need-token/ai-models

A structured YAML catalog of 4,587+ AI models across 95 providers with first-party data including pricing, context windows, modalities, and capabilities.

### Why this is useful for Awesome-LLMOps readers:
- **Model selection** — interactive catalog with search, filter, compare, cost calculator, and model picker
- **First-party data** — pricing and capabilities verified from provider APIs, not aggregators
- **Programmable** — TypeScript types + Zod validation, npm package, GitHub Action
- **81 free models**, 2,350 with tool calling, 1,306 with reasoning, 527 open weights
- **Open source** — MIT-licensed, available as JSON/CSV/YAML

### Placement
Added to the **Large Language Model** table as a comprehensive model catalog resource for LLMOps practitioners who need to select and compare models.

### Checklist
- [x] The entry follows the existing table format
- [x] The entry has a description and badge
- [x] The entry is in the appropriate section