### PR TITLE
Add guard-eval-harness to Security → Frameworks for LLM security

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [brood-box](https://github.com/stacklok/brood-box) | CLI tool for running coding agents inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization. | ![GitHub Badge](https://img.shields.io/github/stars/stacklok/brood-box?style=flat-square) |
 | [dstack](https://github.com/Dstack-TEE/dstack)          | Open-source confidential AI framework for secure LLM deployment with data privacy, providing hardware-enforced isolation using Intel TDX and NVIDIA Confidential Computing. | ![GitHub Badge](https://img.shields.io/github/stars/Dstack-TEE/dstack?style=flat-square) |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
+| [guard-eval-harness](https://github.com/Virtue-Research/guard-eval-harness) | CLI harness for benchmarking LLM safety guardrail and moderation classifier models (Llama Guard, ShieldGemma, WildGuard, OpenAI Moderation, etc.) against 80+ public safety datasets, with consistent metrics (per-threshold F1/AUROC, FPR/FNR tradeoff). MIT licensed. | ![GitHub Badge](https://img.shields.io/github/stars/Virtue-Research/guard-eval-harness.svg?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Hi — thanks for maintaining Awesome-LLMOps, it's been our go-to reference for the LLM-tooling ecosystem.

Adding a single-row entry to **Security → Frameworks for LLM security**, alongside Plexiglass and dstack.

### What it is

[`guard-eval-harness`](https://github.com/Virtue-Research/guard-eval-harness) (`geh`) is an MIT-licensed CLI for benchmarking LLM safety guardrail / moderation classifier models — Llama Guard 3, ShieldGemma, WildGuard, Qwen3-Guard, OpenAI Moderation, and others — against 80+ public safety datasets (XSTest, ToxicChat, HarmBench, BeaverTails, WildGuardMix, JBB, AdvBench, ToxiGen, HateCheck, and more).

```bash
pip install geh
geh run --pack core --model hf --model-name meta-llama/Llama-Guard-3-8B
```

### Why it fits the Security section

The Security section covers tools that **secure** LLM applications (Plexiglass for adversarial testing, dstack for confidential compute, Cordum for policy-evaluated agent orchestration). `geh` is the analogous tool for the **classifier layer** specifically — letting an LLMOps team objectively pick the right safety guardrail model for their pipeline rather than reading 6 different paper-card eval slices.

Per-threshold F1/AUROC and FPR/FNR tradeoff curves are emitted by default, with pluggable adapters for HuggingFace, vLLM (offline + HTTP), OpenAI, Anthropic, and generic HTTP endpoints.

### Changes

- Single-row append to the `### Frameworks for LLM security` table, matching the existing 3-column `Project | Details | Repository` format with the shields.io stars badge.

Thanks!