### PR TITLE
Add llmops-radar to Awesome Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,3 +703,5 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [pleisto/flappy](https://github.com/pleisto/flappy)                                                     | Production-Ready LLM Agent SDK for Every Developer                                                                                | ![GitHub Badge](https://img.shields.io/github/stars/pleisto/flappy.svg?style=flat-square)                                |
 
 **[⬆ back to ToC](#table-of-contents)**
+
+| [llmops-radar](https://github.com/linny006/llmops-radar) | Live, auto-updated index of newest LLMOps tooling (observability, deployment, prompt management) on GitHub, refreshed every 15 minutes. | ![GitHub Badge](https://img.shields.io/github/stars/linny006/llmops-radar.svg?style=flat-square) |


### PR DESCRIPTION
Adds [llmops-radar](https://github.com/linny006/llmops-radar) to the **Awesome Lists** section.

It's a live-updated index of newest LLMOps tools (observability, deployment, prompt management) on GitHub. Updates every 15 minutes via a GitHub Actions cron pulling from the GitHub Search API. Complements the existing curated lists by showing what's actively shipping today, not what was popular when the list was last curated.

- Open source, MIT licensed
- Repo: https://github.com/linny006/llmops-radar
- Live data: https://linny006.github.io/llmops-radar/