### PR TITLE
Add AgentHUD to Observability — game-style HUD overlay for AI agent observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [semantic-coverage](https://github.com/aashirpersonal/semantic-coverage) | Visualizes RAG knowledge gaps and "blind spots" using 2D UMAP clustering and density detection.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
 | [Weco Observe](https://weco.ai) | Observability and debugging tool for AI research agents. Trace multi-step LLM agent runs, visualize decision trees, and identify failure modes in autonomous research workflows. Cloud hosted with open-source agent integration. |                                                                                                                    |
 
+| [AgentHUD](https://github.com/IAMMARBIT/AgentHUD) | Game-style HUD overlay for AI agent observability. Live animated cards per agent with tool calls, tokens, cost, latency, success rate, and sparkline. Drop-in callback handlers for LangChain, OpenAI Agents SDK, Claude Agent SDK, CrewAI, and AutoGen. 14 polished skins + community skin marketplace. Localhost-only, no telemetry, MIT. | ![GitHub Badge](https://img.shields.io/github/stars/IAMMARBIT/AgentHUD?style=flat-square) |
+
 **[⬆ back to ToC](#table-of-contents)**
 
 ## LLMOps


### PR DESCRIPTION
Adding [AgentHUD](https://github.com/IAMMARBIT/AgentHUD) to the **Observability** section (sits naturally alongside Langfuse, Helicone, Traceloop — all peer LLM observability tools).

**What it is:** open-source game-style HUD overlay that shows live cards per agent over your desktop — tool calls, tokens, cost, latency, success rate, sparkline. Drop-in adapters for the major agent frameworks (LangChain, OpenAI Agents SDK, Claude Agent SDK, CrewAI, AutoGen) with 3-line installs:

\`\`\`python
from agenthud.adapters.langchain import AgentHUDCallbackHandler
executor.invoke({"input": "..."}, config={"callbacks": [AgentHUDCallbackHandler()]})
\`\`\`

Different angle from existing entries — game-HUD aesthetic over your desktop instead of web dashboard. Ships 14 polished skins (matrix code rain, holographic foil, jarvis HUD, dead space spine RIG, persona5, more) + a community skin marketplace where designers publish + earn. Native plugin support for Rust / Go / Zig / C binaries (no Python required for plugin authors). MIT licensed, localhost-only, no telemetry, fail-silent SDK.

Just-launched v0.2.0. Happy to adjust the description or section placement if needed.