### PR TITLE
Add AI Security Gateway to Security >  LLM Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [brood-box](https://github.com/stacklok/brood-box) | CLI tool for running coding agents inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization. | ![GitHub Badge](https://img.shields.io/github/stars/stacklok/brood-box?style=flat-square) |
 | [dstack](https://github.com/Dstack-TEE/dstack)          | Open-source confidential AI framework for secure LLM deployment with data privacy, providing hardware-enforced isolation using Intel TDX and NVIDIA Confidential Computing. | ![GitHub Badge](https://img.shields.io/github/stars/Dstack-TEE/dstack?style=flat-square) |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
+| [AI Security Gateway](https://github.com/aisecuritygateway/aisecuritygateway) | Open-source AI firewall with PII redaction (28+ types), prompt injection blocking, and budget enforcement. OpenAI SDK compatible proxy for 600+ LLMs. | ![GitHub Badge](https://img.shields.io/github/stars/aisecuritygateway/aisecuritygateway.svg?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Adding AI Security Gateway to the Guardrails for LLM Security section.

It provides runtime DLP (PII redaction of 28+ entity types), prompt
injection blocking, budget enforcement, and multi-provider routing —
all behind an OpenAI-compatible API.

Differentiator from existing entries: native data loss prevention
built into the gateway layer rather than as a separate service.

- Repo: https://github.com/aisecuritygateway/aisecuritygateway
- License: Apache 2.0