### PR TITLE
Add Seerlens to Observability section

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [Future AGI](https://github.com/future-agi/futureagi-sdk)                    | Production-grade SDK for observability, automated evaluations and prompt management with sub-100ms guardrails for LLM/agent workflows.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
 | [semantic-coverage](https://github.com/aashirpersonal/semantic-coverage) | Visualizes RAG knowledge gaps and "blind spots" using 2D UMAP clustering and density detection.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
 | [Weco Observe](https://weco.ai) | Observability and debugging tool for AI research agents. Trace multi-step LLM agent runs, visualize decision trees, and identify failure modes in autonomous research workflows. Cloud hosted with open-source agent integration. |                                                                                                                    |
+| [Seerlens](https://github.com/eladser/seerlens) | Local-first DevTools for AI calls: live tracing, cost breakdown, and answer-quality evals (keyword or LLM-as-judge) for LLM apps. Built on OpenTelemetry, with .NET, Python, and JS SDKs. | ![GitHub Badge](https://img.shields.io/github/stars/eladser/seerlens.svg?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Adds [Seerlens](https://github.com/eladser/seerlens) to the Observability table.

Seerlens is a local-first DevTools for AI calls: it runs a local dashboard that shows every LLM call an app makes (prompt, completion, cost, tokens, latency, tool calls) and tracks answer-quality regressions over time with an eval engine (keyword or LLM-as-judge scoring against a golden set). Built on the OpenTelemetry GenAI conventions, so any OTLP-instrumented app works; ships SDKs for .NET, Python, and JavaScript and installs as a dotnet tool. MIT licensed.

The entry follows the existing table format with a stars badge.