### PR TITLE
Add NarraNexus to LLMOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [SwarmClaw](https://github.com/swarmclawai/swarmclaw) | Self-hosted multi-agent AI runtime with 23+ LLM providers, persistent memory, skills, schedules, sub-agent spawning, and MCP client + server support. Ships as desktop app, CLI, or Docker. | ![GitHub Badge](https://img.shields.io/github/stars/swarmclawai/swarmclaw.svg?style=flat-square) |
 | [ai-evaluation](https://github.com/future-agi/ai-evaluation) | Evaluation framework for automated, reproducible scoring of LLM, agent, and workflow performance. | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/ai-evaluation?style=flat-square) |
 | [future-agi](https://github.com/future-agi/future-agi) | Open-source self-hostable end-to-end agent engineering and optimization platform unifying tracing, evals, simulations, datasets, gateway, and guardrails for LLM and AI agent applications. | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/future-agi?style=flat-square) |
+| [NarraNexus](https://github.com/NetMindAI-Open/NarraNexus) | Ready-to-run AI agent team workspace by NetMind.AI. Persistent memory across sessions, multi-agent collaboration (PM, developer, deployment, research), composable modules (Memory, RAG, Jobs, Skills), and MCP-style tool integrations. | ![GitHub Badge](https://img.shields.io/github/stars/NetMindAI-Open/NarraNexus.svg?style=flat-square) |
 
 
 **[⬆ back to ToC](#table-of-contents)**


### PR DESCRIPTION
Adds **NarraNexus** (https://github.com/NetMindAI-Open/NarraNexus) to the LLMOps section.

NarraNexus is an open-source, ready-to-run AI agent team workspace by NetMind.AI. Features persistent memory across sessions, multi-agent collaboration, composable modules (Memory, RAG, Jobs, Skills), and MCP-style tool integrations.