### PR TITLE
 Add doceval — LLM document extraction eval harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [SwarmClaw](https://github.com/swarmclawai/swarmclaw) | Self-hosted multi-agent AI runtime with 23+ LLM providers, persistent memory, skills, schedules, sub-agent spawning, and MCP client + server support. Ships as desktop app, CLI, or Docker. | ![GitHub Badge](https://img.shields.io/github/stars/swarmclawai/swarmclaw.svg?style=flat-square) |
 | [ai-evaluation](https://github.com/future-agi/ai-evaluation) | Evaluation framework for automated, reproducible scoring of LLM, agent, and workflow performance. | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/ai-evaluation?style=flat-square) |
 | [future-agi](https://github.com/future-agi/future-agi) | Open-source self-hostable end-to-end agent engineering and optimization platform unifying tracing, evals, simulations, datasets, gateway, and guardrails for LLM and AI agent applications. | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/future-agi?style=flat-square) |
+| [doceval](https://github.com/dave8172/doceval) | Schema-agnostic, model-agnostic field-level accuracy eval harness for LLM document extraction pipelines. Classifies failures as missed_field, hallucination, wrong_format, or wrong_value with numeric and date normalisation across locales. | ![GitHub Badge](https://img.shields.io/github/stars/dave8172/doceval.svg?style=flat-square) |
 
 
 **[⬆ back to ToC](#table-of-contents)**


### PR DESCRIPTION
doceval is an open-source, schema-agnostic eval harness for LLM document extraction pipelines. It classifies extraction failures by type (missed_field, hallucination, wrong_format, wrong_value) with cross-locale numeric/date normalisation. MIT licensed. github.com/dave8172/doceval