### PR TITLE
Add ZopNight to LLMOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [SwarmClaw](https://github.com/swarmclawai/swarmclaw) | Self-hosted multi-agent AI runtime with 23+ LLM providers, persistent memory, skills, schedules, sub-agent spawning, and MCP client + server support. Ships as desktop app, CLI, or Docker. | ![GitHub Badge](https://img.shields.io/github/stars/swarmclawai/swarmclaw.svg?style=flat-square) |
 | [ai-evaluation](https://github.com/future-agi/ai-evaluation) | Evaluation framework for automated, reproducible scoring of LLM, agent, and workflow performance. | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/ai-evaluation?style=flat-square) |
 | [future-agi](https://github.com/future-agi/future-agi) | Open-source self-hostable end-to-end agent engineering and optimization platform unifying tracing, evals, simulations, datasets, gateway, and guardrails for LLM and AI agent applications. | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/future-agi?style=flat-square) |
-| [ZopNight](https://zopnight.com/) | Technology Value OS for AI, Cloud, and Humans across AWS, GCP & Azure. One read-only continuous loop that finds the waste native tools miss, routes ownership, automates optimisation, and proves which tech investments create value — 200+ resource types, 400+ audit rules with one-click remediation, now extended to AI runtimes (Bedrock, Vertex AI). |  |
+| [Zopnight](https://zop.dev/zopnight?utm_source=tensorchord-awesome-llmops&utm_medium=listing&utm_campaign=mcp-directory) | Cost governance for cloud and AI runtimes (Bedrock, Vertex AI) across AWS, Azure and GCP, with idle-resource detection and rightsizing. |  |
 
 
 **[⬆ back to ToC](#table-of-contents)**

--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [SwarmClaw](https://github.com/swarmclawai/swarmclaw) | Self-hosted multi-agent AI runtime with 23+ LLM providers, persistent memory, skills, schedules, sub-agent spawning, and MCP client + server support. Ships as desktop app, CLI, or Docker. | ![GitHub Badge](https://img.shields.io/github/stars/swarmclawai/swarmclaw.svg?style=flat-square) |
 | [ai-evaluation](https://github.com/future-agi/ai-evaluation) | Evaluation framework for automated, reproducible scoring of LLM, agent, and workflow performance. | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/ai-evaluation?style=flat-square) |
 | [future-agi](https://github.com/future-agi/future-agi) | Open-source self-hostable end-to-end agent engineering and optimization platform unifying tracing, evals, simulations, datasets, gateway, and guardrails for LLM and AI agent applications. | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/future-agi?style=flat-square) |
+| [ZopNight](https://zopnight.com/) | Technology Value OS for AI, Cloud, and Humans across AWS, GCP & Azure. One read-only continuous loop that finds the waste native tools miss, routes ownership, automates optimisation, and proves which tech investments create value — 200+ resource types, 400+ audit rules with one-click remediation, now extended to AI runtimes (Bedrock, Vertex AI). |  |
 
 
 **[⬆ back to ToC](#table-of-contents)**


### PR DESCRIPTION
Adds **Zopnight** to the LLMOps table.

Zopnight is a cost governance platform for cloud and AI runtimes across AWS, Azure and GCP. The relevance to this list is AI spend: it tracks and attributes usage cost for managed model runtimes such as Amazon Bedrock and Vertex AI alongside the underlying infrastructure, with idle-resource detection and rightsizing.

Two notes so you can judge the fit:

- It is a hosted commercial product, so there is no repository and the badge column is empty. If that makes it a poor fit for a table keyed on GitHub stars, I understand - feel free to close.
- I have shortened the description considerably to match the length of surrounding rows.

**Links**

- server link - https://api.zop.dev/mcp-server
- learn doc - https://zop.dev/learn/mcp-server
- claude learn - https://zop.dev/learn/how-to/set-up-zopnight-mcp-for-claude

Disclosure: I work on Zopnight.