### PR TITLE
Add IronClaw to Security > Frameworks for LLM security

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [brood-box](https://github.com/stacklok/brood-box) | CLI tool for running coding agents inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization. | ![GitHub Badge](https://img.shields.io/github/stars/stacklok/brood-box?style=flat-square) |
 | [dstack](https://github.com/Dstack-TEE/dstack)          | Open-source confidential AI framework for secure LLM deployment with data privacy, providing hardware-enforced isolation using Intel TDX and NVIDIA Confidential Computing. | ![GitHub Badge](https://img.shields.io/github/stars/Dstack-TEE/dstack?style=flat-square) |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
+| [IronClaw](https://github.com/IronSecCo/ironclaw) | Security-first, self-hosted platform for running AI agents in per-agent gVisor (`runsc`) sandboxes with no network, behind a human approval gateway (deny-by-default), with per-session encrypted (SQLCipher) queues and a signed, attested supply chain (cosign, SBOM, provenance). | ![GitHub Badge](https://img.shields.io/github/stars/IronSecCo/ironclaw.svg?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Adds [IronClaw](https://github.com/IronSecCo/ironclaw) to **Security → Frameworks for LLM security**, alongside the existing agent-isolation entries (brood-box, dstack, Cordum).

IronClaw is a security-first, self-hosted platform for running AI agents in isolation:
- Each agent runs in a per-agent gVisor (`runsc`) sandbox with `network=none` — the model is reached only through a host proxy.
- Capability changes are held at a human approval gateway (deny-by-default).
- Per-session message queues are encrypted with SQLCipher.
- Releases ship a signed, attested supply chain (cosign signatures, SBOMs, build provenance).

Appended to the bottom of the subsection table, matching the existing 3-column format. One item. AGPLv3, Go.