### PR TITLE
Add AgentSentry Gateway (Frameworks for LLM security)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [brood-box](https://github.com/stacklok/brood-box) | CLI tool for running coding agents inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization. | ![GitHub Badge](https://img.shields.io/github/stars/stacklok/brood-box?style=flat-square) |
 | [dstack](https://github.com/Dstack-TEE/dstack)          | Open-source confidential AI framework for secure LLM deployment with data privacy, providing hardware-enforced isolation using Intel TDX and NVIDIA Confidential Computing. | ![GitHub Badge](https://img.shields.io/github/stars/Dstack-TEE/dstack?style=flat-square) |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
+| [AgentSentry Gateway](https://github.com/akav-labs/agentsentry-gateway) | Transparent OpenAI-compatible security gateway (Rust) that scans LLM traffic at the egress for secret/PII leaks, jailbreaks, and prompt injection; blocks violations and forwards clean traffic untouched. Normalizes Unicode homoglyphs to resist look-alike evasion. | ![GitHub Badge](https://img.shields.io/github/stars/akav-labs/agentsentry-gateway.svg?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Adds **AgentSentry Gateway** to *Security → Frameworks for LLM security*.

It's a transparent, OpenAI-compatible security gateway (Rust, Apache-2.0) that sits in front of LLM/agent traffic and scans every request at the egress for secret/PII leaks, jailbreaks, and prompt injection — blocking violations and forwarding clean traffic untouched. It also normalizes Unicode homoglyphs before matching to resist look-alike evasion. Fits alongside the existing output-scanning / LLM-security tools in this section.

Repo: https://github.com/akav-labs/agentsentry-gateway

One table row added, matching the section's existing format. Thanks for maintaining the list!