### PR TITLE
Add BenchGen to Observability section

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [Future AGI](https://github.com/future-agi/futureagi-sdk)                    | Production-grade SDK for observability, automated evaluations and prompt management with sub-100ms guardrails for LLM/agent workflows.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
 | [semantic-coverage](https://github.com/aashirpersonal/semantic-coverage) | Visualizes RAG knowledge gaps and "blind spots" using 2D UMAP clustering and density detection.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
 | [Weco Observe](https://weco.ai) | Observability and debugging tool for AI research agents. Trace multi-step LLM agent runs, visualize decision trees, and identify failure modes in autonomous research workflows. Cloud hosted with open-source agent integration. |                                                                                                                    |
+| [BenchGen](https://benchgen.com) | AI agent benchmarking and evaluation platform. Run structured benchmark suites, score agents across tool-call accuracy, goal completion, and skill coverage, then export filtered trajectories for LoRA fine-tuning. |                                                                                                                    |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Hi! Adding BenchGen (https://benchgen.com) to the Observability section.

It's an AI agent benchmarking and evaluation platform — you run benchmark suites against your agent and it scores performance across tool-call accuracy, goal completion, and skill coverage. It also exports filtered trajectory data for LoRA fine-tuning, which makes it useful beyond just monitoring.

Feels like a natural fit alongside Langfuse, Maxim AI, and the other eval/observability tools already in this section. Happy to adjust if you'd prefer a different placement.