### PR TITLE
Add flare-redact to Frameworks for LLM security

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [brood-box](https://github.com/stacklok/brood-box) | CLI tool for running coding agents inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization. | ![GitHub Badge](https://img.shields.io/github/stars/stacklok/brood-box?style=flat-square) |
 | [dstack](https://github.com/Dstack-TEE/dstack)          | Open-source confidential AI framework for secure LLM deployment with data privacy, providing hardware-enforced isolation using Intel TDX and NVIDIA Confidential Computing. | ![GitHub Badge](https://img.shields.io/github/stars/Dstack-TEE/dstack?style=flat-square) |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
+| [flare-redact](https://github.com/flare-collection/flare-redact) | Zero-dependency secret & PII redaction for LLM pipelines: wraps OpenAI/Anthropic clients, strips sensitive values from prompts and tool calls, and reversibly restores them in replies. | ![GitHub Badge](https://img.shields.io/github/stars/flare-collection/flare-redact?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Adds [flare-redact](https://github.com/flare-collection/flare-redact) to **Security → Frameworks for LLM security**, following the existing table format.

flare-redact is an MIT-licensed, zero-dependency TypeScript library for LLM privacy: it wraps OpenAI/Anthropic clients so secrets and PII (75 detectors, checksum-validated) are stripped from prompts and tool-call arguments before the request leaves the process, then reversibly restored in the model's reply — including placeholders split across streaming chunks. Runs locally on Node/Bun/Deno/browser with no model download or network calls.