### PR TITLE
Add Shim to Frameworks for LLM security

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [brood-box](https://github.com/stacklok/brood-box) | CLI tool for running coding agents inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization. | ![GitHub Badge](https://img.shields.io/github/stars/stacklok/brood-box?style=flat-square) |
 | [dstack](https://github.com/Dstack-TEE/dstack)          | Open-source confidential AI framework for secure LLM deployment with data privacy, providing hardware-enforced isolation using Intel TDX and NVIDIA Confidential Computing. | ![GitHub Badge](https://img.shields.io/github/stars/Dstack-TEE/dstack?style=flat-square) |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
+| [Shim](https://getshim.tech) | Compliance-oriented AI gateway that redacts PII before prompts reach model providers (Presidio plus Turkish TCKN/VKN recognizers) and writes a tamper-evident hash-chain audit log with daily Merkle anchors as EU AI Act and KVKK evidence. |  |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Adds [Shim](https://getshim.tech) to `Security → Frameworks for LLM security`.

| [Shim](https://getshim.tech) | Compliance-oriented AI gateway that redacts PII before prompts reach model providers (Presidio plus Turkish TCKN/VKN recognizers) and writes a tamper-evident hash-chain audit log with daily Merkle anchors as EU AI Act and KVKK evidence. |  |

**Why this section:** it sits on the request path in front of OpenAI/Anthropic/Gemini/Ollama and its job is preventing sensitive data from leaving plus producing evidence that it didn't — closest neighbour here is Cordum (output scanning + audit trail). The differentiator is coverage of a local regime: Turkish TCKN/VKN and TR IBAN recognizers layered on Presidio, which the general-purpose PII layers don't include.

**Notes:**

- Repository column left empty — Shim is a commercial product with public docs and a free tier rather than a public repo, matching the existing no-repo entries in this list (ClevAgent, Maxim AI, Humanloop, Vellum, TrueFoundry and others).
- No `scripts/` changes, so no star badges or ToC regeneration needed.
- One suggestion per PR, per contributing.md.

Disclosure: I work on Shim, so please read this as a self-submission. Happy to reword, move it to LLMOps instead, or drop it if you'd rather not carry closed-source gateways in the security section.