### PR TITLE
Add SourceryKit to Security > Frameworks for LLM security

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [brood-box](https://github.com/stacklok/brood-box) | CLI tool for running coding agents inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization. | ![GitHub Badge](https://img.shields.io/github/stars/stacklok/brood-box?style=flat-square) |
 | [dstack](https://github.com/Dstack-TEE/dstack)          | Open-source confidential AI framework for secure LLM deployment with data privacy, providing hardware-enforced isolation using Intel TDX and NVIDIA Confidential Computing. | ![GitHub Badge](https://img.shields.io/github/stars/Dstack-TEE/dstack?style=flat-square) |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
+| [SourceryKit](https://github.com/ProvablyAI/sourcerykit) | Verifies an agent's outbound HTTP and MCP calls against a source of truth using zero-knowledge proofs, so a call only goes out if the agent's claims check out. Hooks into the HTTP libraries, logs every call, and blocks anything off the trusted-endpoint allow-list. Python SDK, source-available (BSL 1.1). | ![GitHub Badge](https://img.shields.io/github/stars/ProvablyAI/sourcerykit.svg?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Hi, opened this to add SourceryKit to Security > Frameworks for LLM security, alongside brood-box and Cordum.

It's a Python SDK that verifies an agent's outbound HTTP and MCP calls against a source of truth using zero-knowledge proofs, so a call only goes out if the agent's claims check out. It hooks into the HTTP libraries, logs each outbound call, and blocks anything that isn't on the trusted-endpoint allow-list. Source-available under BSL 1.1, with a hosted backend for the proof check.

Kept it to one table row in your format. Thanks for maintaining the list.