### PR TITLE
Add PolicyStrata

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [brood-box](https://github.com/stacklok/brood-box) | CLI tool for running coding agents inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization. | ![GitHub Badge](https://img.shields.io/github/stars/stacklok/brood-box?style=flat-square) |
 | [dstack](https://github.com/Dstack-TEE/dstack)          | Open-source confidential AI framework for secure LLM deployment with data privacy, providing hardware-enforced isolation using Intel TDX and NVIDIA Confidential Computing. | ![GitHub Badge](https://img.shields.io/github/stars/Dstack-TEE/dstack?style=flat-square) |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
+| [PolicyStrata](https://github.com/raintree-technology/policystrata) | Deterministic policy regression testing for LLM data-agent stacks, with CI checks across tool manifests, semantic validation, SQL compilation, database controls, and result release. | ![GitHub Badge](https://img.shields.io/github/stars/raintree-technology/policystrata?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
## Summary

- add [PolicyStrata](https://github.com/raintree-technology/policystrata) to Security / Frameworks for LLM security
- describe it as a CI-oriented security and policy-regression framework

## Why

PolicyStrata is an MIT-licensed, local-first project for deterministic policy regression testing in LLM data-agent stacks. It checks policy responsibilities across model-visible tools, semantic validation, SQL compilation, database controls, and result release.

I maintain PolicyStrata and am disclosing that relationship with this submission.

## Checks

- `git diff --check`
- verified the repository link and entry format