### PR TITLE
Add Tulip to Frameworks for LLM security

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [brood-box](https://github.com/stacklok/brood-box) | CLI tool for running coding agents inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization. | ![GitHub Badge](https://img.shields.io/github/stars/stacklok/brood-box?style=flat-square) |
 | [dstack](https://github.com/Dstack-TEE/dstack)          | Open-source confidential AI framework for secure LLM deployment with data privacy, providing hardware-enforced isolation using Intel TDX and NVIDIA Confidential Computing. | ![GitHub Badge](https://img.shields.io/github/stars/Dstack-TEE/dstack?style=flat-square) |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
+| [Tulip](https://github.com/tuliplabs-ai/sdk-python) | Agent framework where control is native: a deterministic router picks the execution shape, typed grounding checks claims against evidence, and an admission gate clears every consequential tool call against policy before it runs, onto a hash-chained audit trail. Wraps tools in existing LangChain/CrewAI/OpenAI Agents SDK apps too. | ![GitHub Badge](https://img.shields.io/github/stars/tuliplabs-ai/sdk-python?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Adds [Tulip](https://github.com/tuliplabs-ai/sdk-python) to **Security → Frameworks for LLM security**.

An Apache-2.0 agent framework where control is part of the runtime rather than the prompt: a deterministic router picks the execution shape, typed grounding checks claims against evidence before they ship, and an admission gate clears every consequential tool call against a policy — allow, hold for a human, or deny — writing each decision to a hash-chained audit trail. It can also wrap tools in an existing LangChain / CrewAI / OpenAI Agents SDK app.

Placed in that section because it sits naturally beside the entries already there — Cordum (pre-dispatch policy evaluation, audit trail) and brood-box (isolation, MCP authorization) — without duplicating either: Tulip's gate is in-process at the tool-call seam rather than a proxy in front of it or a sandbox boundary around it.

Per the contribution guidelines: one PR for one suggestion, existing table shape, star badge included, ordered after Plexiglass.
