### PR TITLE
Add RelayPlane to LLMOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [SwarmClaw](https://github.com/swarmclawai/swarmclaw) | Self-hosted multi-agent AI runtime with 23+ LLM providers, persistent memory, skills, schedules, sub-agent spawning, and MCP client + server support. Ships as desktop app, CLI, or Docker. | ![GitHub Badge](https://img.shields.io/github/stars/swarmclawai/swarmclaw.svg?style=flat-square) |
 | [ai-evaluation](https://github.com/future-agi/ai-evaluation) | Evaluation framework for automated, reproducible scoring of LLM, agent, and workflow performance. | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/ai-evaluation?style=flat-square) |
 | [future-agi](https://github.com/future-agi/future-agi) | Open-source self-hostable end-to-end agent engineering and optimization platform unifying tracing, evals, simulations, datasets, gateway, and guardrails for LLM and AI agent applications. | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/future-agi?style=flat-square) |
+| [RelayPlane](https://github.com/RelayPlane/proxy) | Open-source cost-intelligence proxy and OpenAI-compatible LLM gateway for AI agents. Smart model routing across 11 providers, a policy engine, and a dashboard to cut API spend. MIT licensed. | ![GitHub Badge](https://img.shields.io/github/stars/RelayPlane/proxy.svg?style=flat-square) |
 
 
 **[⬆ back to ToC](#table-of-contents)**


### PR DESCRIPTION
Adds [RelayPlane](https://github.com/RelayPlane/proxy) to the LLMOps section.

RelayPlane is an open-source (MIT), OpenAI-compatible LLM gateway / cost-intelligence proxy for AI agents: smart model routing across 11 providers, a policy engine, and a dashboard for cutting API spend. It sits alongside the other gateway/routing tools already listed here (LiteLLM, Glide, Portkey, TensorZero).

Entry follows the existing table format (Project | Details | Repository with a stars badge) and is appended to the end of the LLMOps table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)