### PR TITLE
Add piighost to Security frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [brood-box](https://github.com/stacklok/brood-box) | CLI tool for running coding agents inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization. | ![GitHub Badge](https://img.shields.io/github/stars/stacklok/brood-box?style=flat-square) |
 | [dstack](https://github.com/Dstack-TEE/dstack)          | Open-source confidential AI framework for secure LLM deployment with data privacy, providing hardware-enforced isolation using Intel TDX and NVIDIA Confidential Computing. | ![GitHub Badge](https://img.shields.io/github/stars/Dstack-TEE/dstack?style=flat-square) |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
+| [piighost](https://github.com/Athroniaeth/piighost) | Anonymizes PII before it reaches the LLM by replacing values with placeholders and restoring them in the reply, so the provider only sees placeholders. Works as LangChain, Pydantic AI or LlamaIndex integrations, or an OpenAI-compatible proxy. | ![GitHub Badge](https://img.shields.io/github/stars/Athroniaeth/piighost.svg?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Adds piighost to Security > Frameworks for LLM security.

piighost anonymizes PII before it reaches the LLM: personal data becomes placeholders like `<<PERSON:1>>`, the model only sees the placeholders, and the real values are restored in the reply. The same value keeps the same placeholder across a conversation and tool calls. It works as a LangChain/LangGraph middleware, Pydantic AI hooks, LlamaIndex, or an OpenAI-compatible proxy. MIT, on PyPI, with docs and examples.

Repo: https://github.com/Athroniaeth/piighost
Docs: https://athroniaeth.github.io/piighost/
