### PR TITLE
Add Sentinel Scan CLI to Frameworks for LLM security

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [brood-box](https://github.com/stacklok/brood-box) | CLI tool for running coding agents inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization. | ![GitHub Badge](https://img.shields.io/github/stars/stacklok/brood-box?style=flat-square) |
 | [dstack](https://github.com/Dstack-TEE/dstack)          | Open-source confidential AI framework for secure LLM deployment with data privacy, providing hardware-enforced isolation using Intel TDX and NVIDIA Confidential Computing. | ![GitHub Badge](https://img.shields.io/github/stars/Dstack-TEE/dstack?style=flat-square) |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
+| [Sentinel Scan CLI](https://github.com/Ventrova/sentinel-scan-cli) | Free CLI that runs a 15-attack prompt-injection and jailbreak suite against your own LLM endpoint, producing a scored report with real findings. | ![GitHub Badge](https://img.shields.io/github/stars/Ventrova/sentinel-scan-cli.svg?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
Adds [Sentinel Scan CLI](https://github.com/Ventrova/sentinel-scan-cli), a free CLI that runs a 15-attack prompt-injection and jailbreak suite against your own LLM endpoint and produces a scored report with real findings. MIT licensed.