### PR TITLE
Add PrivacyScrubber to LLM Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [brood-box](https://github.com/stacklok/brood-box) | CLI tool for running coding agents inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization. | ![GitHub Badge](https://img.shields.io/github/stars/stacklok/brood-box?style=flat-square) |
 | [dstack](https://github.com/Dstack-TEE/dstack)          | Open-source confidential AI framework for secure LLM deployment with data privacy, providing hardware-enforced isolation using Intel TDX and NVIDIA Confidential Computing. | ![GitHub Badge](https://img.shields.io/github/stars/Dstack-TEE/dstack?style=flat-square) |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
+| [PrivacyScrubber](https://github.com/moxno/privacyscrubber-mcp) | Zero-Trust client-side PII and developer secrets sanitizer and MCP server for Cursor, Windsurf, and Claude Desktop with sub-2ms in-memory tokenization. | ![GitHub Badge](https://img.shields.io/github/stars/moxno/privacyscrubber-mcp.svg?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
### What does this PR add?
Adds **PrivacyScrubber** to the **Security -> Frameworks for LLM security** section.

### About PrivacyScrubber
- **Repository**: https://github.com/moxno/privacyscrubber-mcp
- **NPM Package**: `@privacyscrubber/mcp-server`
- **Details**: 100% client-side, zero-trust PII & developer secrets sanitizer and MCP server for Cursor, Windsurf, and Claude Desktop with sub-2ms in-memory tokenization and 1-click token restoration.
