### PR TITLE
Add fastdocparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [Feast](https://github.com/feast-dev/feast)            | An open source feature store for machine learning.                                                                                                                                                                                                                  | ![GitHub Badge](https://img.shields.io/github/stars/feast-dev/feast.svg?style=flat-square)       |
 | [distilabel](https://github.com/argilla-io/distilabel) | ⚗️ distilabel is a framework for synthetic data and AI feedback for AI engineers that require high-quality outputs, full data ownership, and overall efficiency.                                                                                                    | ![GitHub Badge](https://img.shields.io/github/stars/argilla-io/distilabel.svg?style=flat-square) |
 | [FastDatasets](https://github.com/ZhuLinsen/FastDatasets) | A powerful tool for creating high-quality training datasets for Large Language Models. | ![GitHub Badge](https://img.shields.io/github/stars/ZhuLinsen/FastDatasets.svg?style=flat-square) |
+| [fastdocparse](https://github.com/pranjalparmar/fastdocparse) | Extracts structured data from documents with an LLM, then grounds every field against the source text to flag hallucinated values automatically. | ![GitHub Badge](https://img.shields.io/github/stars/pranjalparmar/fastdocparse.svg?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
fastdocparse extracts structured data from documents (invoices, forms, resumes) using any OpenAI-compatible LLM, then grounds every field against the source text to flag hallucinated/ungrounded values automatically — no extra LLM call. MIT licensed, typed, 74 tests.

Repo: https://github.com/pranjalparmar/fastdocparse