### PR TITLE
Add tonst to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [brood-box](https://github.com/stacklok/brood-box) | CLI tool for running coding agents inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization. | ![GitHub Badge](https://img.shields.io/github/stars/stacklok/brood-box?style=flat-square) |
 | [dstack](https://github.com/Dstack-TEE/dstack)          | Open-source confidential AI framework for secure LLM deployment with data privacy, providing hardware-enforced isolation using Intel TDX and NVIDIA Confidential Computing. | ![GitHub Badge](https://img.shields.io/github/stars/Dstack-TEE/dstack?style=flat-square) |
 | [Plexiglass](https://github.com/kortex-labs/plexiglass) | A Python Machine Learning Pentesting Toolbox for Adversarial Attacks. Works with LLMs, DNNs, and other machine learning algorithms. | ![GitHub Badge](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=flat-square) |
+| tonst | Local-first token optimization (caching + trimming) and PII redaction for LLM API calls, with a local-LLM layer for free-text PII detection. | [GitHub Badge](https://github.com/v-nightwolf/tonst) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
## What My Project Does

tonst is a lightweight Python SDK that wraps your existing LLM API calls (Claude, OpenAI, or any provider) and reduces token spend before the request ever leaves your machine. It does this through:

- Semantic caching — skips the paid API call entirely on near-duplicate queries (bag-of-words similarity in this version, swappable for real embeddings)
- Mechanical trimming — dedupes repeated lines, strips bloated whitespace, truncates old chat history
- Local PII redaction — regex for structured data (emails, cards, phones), plus an optional local-LLM pass (via Ollama) for free-text PII like names and addresses, with a guard rail that only redacts spans it can verify actually exist in the source text
- Provider-agnostic — you pass in your own `call_fn`, so it wraps whatever API client you're already using

Tested against the real Claude API: 26.9% token reduction on a realistic prompt with duplicated instructions and embedded PII.

## Target Audience

This is a working proof-of-concept, not yet production-hardened. It's aimed at developers building LLM-powered apps who want to cut API costs and reduce PII exposure without standing up a server or gateway. The core redaction/caching logic is solid and tested (15 pytest tests), but a few pieces are explicitly stubbed for now — the semantic cache uses bag-of-words similarity rather than real embeddings, and the in-memory cache doesn't persist across restarts. The README documents exactly which parts are production-ready vs. which are simplifications, so you can judge for yourself before relying on it for anything serious.

## Comparison

Most existing tools in this space (LiteLLM's gateway, LLMShield, various AI-gateway samples) are server-side proxies — you run them as separate infrastructure, and PII redaction is regex-only, which can't catch free-text PII like a name or address in a sentence.

tonst is different on both counts: it's an in-process library (no server to run or maintain), and its redaction pipeline has a second stage using a local model for free-text PII that regex structurally can't catch, with a hallucination guard rail to keep that safe.

It doesn't try to be a full gateway (no multi-provider routing, no dashboard, no rate limiting) — it's intentionally narrower in scope, focused on cost + privacy at the point where the request originates.

MIT licensed: github.com/v-nightwolf/tonst