### PR TITLE
Add Kapso to Code AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [promptext](https://github.com/1broseidon/promptext) | Smart code context extractor for AI assistants with accurate token counting and budget management        | ![GitHub Badge](https://img.shields.io/github/stars/1broseidon/promptext.svg?style=flat-square) |
 | [tabby](https://github.com/TabbyML/tabby)           | Self-hosted AI coding assistant. An opensource / on-prem alternative to GitHub Copilot.                  | ![GitHub Badge](https://img.shields.io/github/stars/TabbyML/tabby.svg?style=flat-square)        |
 | [AIDE](https://github.com/WecoAI/aideml)            | Open-source ML engineering agent that uses tree search to explore solution spaces. Automates machine learning experimentation from data analysis to model training. [Paper](https://arxiv.org/abs/2502.13138). | ![GitHub Badge](https://img.shields.io/github/stars/WecoAI/aideml.svg?style=flat-square)        |
+| [Kapso](https://github.com/Leeroo-AI/kapso) | A self-improving AI software factory (for measurable objectives). \#1 open-source on MLE-Bench; ALE-Bench; RelBench. | ![GitHub Badge](https://img.shields.io/github/stars/Leeroo-AI/kapso.svg?style=flat-square) |
 
 ## Training
 


### PR DESCRIPTION
Hi,

**What Kapso is.** Kapso is a self-improving software factory. State an objective and it runs a campaign: it designs candidate solutions, has coding agents (Claude Code or Codex) implement them, measures how far each one is from the objective, and keeps refining the closest until the objective is met. The result ships to the user's infrastructure.

The factory improves with use. When a campaign ends, Kapso studies its own work: which ideas closed the distance to the objective, which did not, and under what conditions. Each finding is kept as a lesson with the evidence that earned it, and a lesson stays trusted only as long as it keeps holding up. Kapso also reads outside the user's walls, repositories and papers, and folds what it finds into the same knowledge hub. Every new campaign begins from that hub.

MIT-licensed, `pip install leeroo-kapso`, docs at https://docs.leeroo.com/docs. Active since 2025-12, latest release 0.4.3 (2026-09-06).

**Benchmarks.** Each has a runner and a write-up under `benchmarks/` in the repo.

- **MLE-Bench** (OpenAI) puts an agent in front of Kaggle competitions, raw data to graded submission, and scores it by medal rate across difficulty splits. Kapso ranks first among open-source systems, with an official submission to the leaderboard (2025-12).
- **ALE-Bench** (Sakana AI) covers AtCoder Heuristic Contest problems: long-horizon algorithmic optimization, rated in Elo against the contest field. Kapso reaches 1909 Elo against ALE Agent's 1879 under the same time budget and the official scorer, first on the benchmark.
- **RelBench** (Stanford and Kumo) is predictive ML over relational databases: 11 databases, 66 tasks across classification, regression and recommendation. Kapso is ahead of KumoRFM-v2, the relational foundation model, on outcome prediction (81.2 vs 79.6 AUROC over 12 tasks) and forecasting (0.2476 vs 0.2912 NMAE over 9 tasks), and has the best reported result on recommendations (18.4 vs 15.7 MAP over 10 tasks). Results are on the official RelBench leaderboard.
- **IOAI 2026, AI Model Track.** The International Olympiad in AI opened its exam to AI systems: six expert-designed tasks, a single-GPU budget, two fully autonomous six-hour sessions with no human help once the clock starts. Kapso scored 536.07, above all 471 human contestants from 108 countries, and took the Grand Master Trophy as one of the top three AI systems entered.

The entry follows the list's format; happy to adjust wording or placement.
