### PR TITLE
Add Failproof to Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ An awesome & curated list of the best LLMOps tools for developers.
 | [Future AGI](https://github.com/future-agi/futureagi-sdk)                    | Production-grade SDK for observability, automated evaluations and prompt management with sub-100ms guardrails for LLM/agent workflows.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
 | [semantic-coverage](https://github.com/aashirpersonal/semantic-coverage) | Visualizes RAG knowledge gaps and "blind spots" using 2D UMAP clustering and density detection.                                             | ![GitHub Badge](https://img.shields.io/github/stars/future-agi/futureagi-sdk?style=flat-square)                   |
 | [Weco Observe](https://weco.ai) | Observability and debugging tool for AI research agents. Trace multi-step LLM agent runs, visualize decision trees, and identify failure modes in autonomous research workflows. Cloud hosted with open-source agent integration. |                                                                                                                    |
+| [Failproof](https://befailproof.ai) | Agentic live tracing for your agents to find failure modes and then prevent them with policies. | ![GitHub Badge](https://img.shields.io/github/stars/FailproofAI/failproofai.svg?style=flat-square) |
 
 **[⬆ back to ToC](#table-of-contents)**
 


### PR DESCRIPTION
## What

Adds [Failproof](https://befailproof.ai) to the Observability section.

## Why

Failproof is a runtime reliability layer for AI agents (Claude Code, Codex, Cursor, Copilot, Gemini CLI, OpenCode, Goose, LangGraph, and more): it traces every prompt and tool call with live replay for a full audit trail, with optional runtime policy enforcement to steer agent behavior when you're ready to move from observing to steering. Fits alongside the other tracing/observability tools already in this section (Helicone, Langfuse, OpenLLMetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)